### PR TITLE
Add total pages to slash command list-mapping-tracking

### DIFF
--- a/src/server/discord/commands/list-mapping-tracking.ts
+++ b/src/server/discord/commands/list-mapping-tracking.ts
@@ -1,0 +1,69 @@
+import { SlashCommand, SlashCommandReturn } from "../models/slash-command";
+import { User, UserMappingTrack } from "../../models/user";
+import { ErrorResponse } from "../responses/error";
+import { ListMappingTrackingResponse } from "../responses/list-mapping-tracking";
+
+export default <SlashCommand>{
+	commandEnum: "LISTTRACKING",
+	name: "list-mapping-track",
+	description: "Lista a los usuarios que están siendo trackeados (Mapping)",
+	options: [
+		{
+			name: "offset",
+			description: "Especifique la página a mostrar, comenzando desde 0.",
+			type: "INTEGER",
+			required: false,
+		},
+	],
+	async call({ interaction, logger }): Promise<SlashCommandReturn> {
+		try {
+			const guildMember =
+				interaction.options.getUser("discord", false) ||
+				interaction.member.user;
+			const userDb = await User.findOne({
+				"discord.userID": guildMember.id,
+			});
+
+			if (!userDb) {
+				return {
+					message: {
+						content:
+							"El usuario no tiene ninguna cuenta de osu! vinculada.",
+					},
+				};
+			}
+
+			const totalTrackedUsers = (await UserMappingTrack.find()
+				.count()) as number;
+
+			if (totalTrackedUsers === 0) {
+				return {
+					message: {
+						content: `Ningún jugador está siendo trackeado por el momento.`,
+					},
+				};
+			}
+
+			const offset = interaction.options.getInteger("offset", false) || 0;
+			const limit = 10;
+
+			const ret = (await UserMappingTrack.find()
+				.skip(offset * limit)
+				.limit(limit)) as UserMappingTrack[];
+
+			const totalPages = (totalTrackedUsers % 10 === 0 ?
+				Math.floor(totalTrackedUsers / limit):
+				Math.floor(totalTrackedUsers / limit) + 1);
+
+			return {
+				message: await new ListMappingTrackingResponse().getMessage(
+					ret, offset, totalPages
+				),
+			};
+		} catch (e) {
+			return {
+				message: await new ErrorResponse().getMessage(e, logger),
+			};
+		}
+	},
+};

--- a/src/server/discord/responses/list-mapping-tracking.ts
+++ b/src/server/discord/responses/list-mapping-tracking.ts
@@ -1,0 +1,35 @@
+import { MessageOptions } from "discord.js";
+import { CommandResponse } from "../../models/command-response";
+import { UserMappingTrack } from "../../models/user";
+import { OUser } from "../../models/osu-api/user";
+import { OsuApi } from "../../util/api/osu-api";
+
+export class ListMappingTrackingResponse implements CommandResponse {
+	async getMessage(
+		UsersInTracking: UserMappingTrack[],
+		offset: number,
+		totalPages: number
+	): Promise<MessageOptions> {
+		let user: OUser = null;
+		let content = "";
+		for (const TrackedUser of UsersInTracking) {
+			user = (await OsuApi.fetchUserPublic(
+				TrackedUser.userID.toString(),
+				"osu"
+			)) as OUser;
+			content += `▸ ${user.username}` + "\n";
+		}
+
+		return {
+			embeds: [
+				{
+					title: `Mostrando usuarios trackeados`,
+					description: content,
+					footer: {
+						text: `Pagina ${offset + 1}/${totalPages}`,
+					},
+				},
+			],
+		};
+	}
+}


### PR DESCRIPTION
Footer now shows the total of pages for every 10 tracked users.